### PR TITLE
Update q2.html-Updated the below description.

### DIFF
--- a/q2.html
+++ b/q2.html
@@ -5,18 +5,18 @@
     <title>Alberta Active Fires</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.3/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
     <style>
         #mapid {
             height: 600px;
         }
     </style>
 </head>
-
 <body>
     <div id="mapid"></div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.3/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script>
         var map = L.map('mapid').setView([55, -113], 5);
 
@@ -24,30 +24,45 @@
             attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors'
         }).addTo(map);
 
-        fetch('https://cwfis.cfs.nrcan.gc.ca/geoserver/public/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=public:activefires_current&srsname=EPSG:4326&outputFormat=json')
+        fetch('https://cwfis.cfs.nrcan.gc.ca/geoserver/public/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=public:activefires_current&srsname=EPSG:4326&outputFormat=json&CQL_FILTER=properties%3aagency=%27ab%27')
             .then(response => response.json())
             .then(data => {
                 L.geoJSON(data.features, {
                     style: function (feature) {
+                        var hectares = feature.properties.hectares;
                         var options = {
-                            color: '#FF0000',
-                            weight: 2,
-                            fillOpacity: 0.5
-                        }
+                        color: '#FF0000',
+                        weight: 2,
+                        fillOpacity: (hectares >= 1 && hectares <= 1000) ? 0.5 : (hectares < 1 || hectares === null) ? 0 : 1
+                        }                      
                         return options;
                     },
                     onEachFeature: function (feature, layer) {
-                        var popupContent = "<p>"
-                            + "Size: " + feature.properties.hectares + "<br/>"
-                            + "</p>";
-                        layer.bindPopup(popupContent);
-                    },
-                    pointToLayer: function (feature, latlng) {
+                        // Function to display fire details
+                        function displayFireInfo() { 
+                            var popupContent = "<p>";
+                           if (feature.properties.firename) {
+                             popupContent += "<b>Name:</b> " + feature.properties.firename + "<br/>";
+                           }
+                           if (feature.properties.stage_of_control) {
+                             popupContent += "<b>Stage of Control:</b> " + feature.properties.stage_of_control + "<br/>";
+                           }
+                            if (feature.properties.startdate) {
+                              var date = new Date(feature.properties.startdate); 
+                              var formattedDate = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+                                popupContent += "<b>Start Date:</b> " + formattedDate + "<br/>";
+                             }  
+                             popupContent += "</p>";
+                             layer.bindPopup(popupContent).openPopup(); 
+                          }
+                          layer.on('click', displayFireInfo);
+            },
+            pointToLayer: function (feature, latlng) {
                         return L.circleMarker(latlng);
                     }
                 }).addTo(map);
             });
     </script>
 </body>
-
+    
 </html>


### PR DESCRIPTION
additional features to show the fire's name, start date, and control status extra hectares of opacity control
<1 will be transparent, and #>1 will be opaque.
the fetch request now has an added Alberta filter -> Will only remove commits from Alberta When the leaflet CDN was switched, Cloudflare reported a local error. #If you're working on other networks or devices, you can ignore this. added a leaflet library integrity check